### PR TITLE
build: fix generate_protos session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ pylintrc.test
 
 # Exclude python-asset which is copied for testing
 python-asset/
+
+# Exclude api-common-protos which is only needed for generation
+api-common-protos


### PR DESCRIPTION
Uncomment `generate_protos` and clone `api-common-protos` inside the session so it can be run in autosynth.

Fixes #27  🦕

Verify locally by doing `nox -s generate_protos` (no additional setup should be required)