### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "accesscontextmanager",
     "name_pretty": "Access Context Manager",
-    "client_documentation": "https://googleapis.dev/python/accesscontextmanager/latest",
+    "client_documentation": "http://cloud.google.com/python/docs/reference/accesscontextmanager/latest",
     "issue_tracker": "https://github.com/googleapis/python-access-context-manager/issues",
     "release_level": "beta",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.