### PR TITLE
chore: test minimum dependencies in python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ version = "0.1.11"
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
     "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
-    "protobuf >= 3.12.0, <4.0.0dev",
+    "protobuf >= 3.19.0, <4.0.0dev",
 ]
 
 # Setup boilerplate below this line.

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,5 +5,5 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-protobuf==3.12.0
+protobuf==3.19.0
 google-api-core==1.31.5

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -5,5 +5,5 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-protobuf==3.12.0
+protobuf==3.19.0
 google-api-core==1.31.5

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -1,0 +1,9 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+protobuf==3.12.0
+google-api-core==1.31.5


### PR DESCRIPTION
Test the minimum supported dependencies in python 3.7 unit tests to prepare for dropping python 3.6

fix(deps): require protobuf>=3.19.0