### PR TITLE
chore: update docfx minimum Python version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -337,13 +337,15 @@ def docs(session):
     )
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.10")
 def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
     session.install(
-        "sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml"
+        "gcp-sphinx-docfx-yaml",
+        "alabaster",
+        "recommonmark",
     )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -220,7 +220,9 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=["3.7", "3.8", "3.9"])
 @nox.parametrize(
     "library",
-    ["python-asset"],
+    [
+        ("google-cloud-python", "google-cloud-asset"),
+    ],
     ids=["asset"],
 )
 def test(session, library):
@@ -230,6 +232,9 @@ def test(session, library):
     NOTE: The unit and system test functions above are copied from the templates.
     They will need to be updated when the templates change.
     """
+    package = ""
+    if type(library) == tuple:
+            library, package = library
     try:
         session.run("git", "-C", library, "pull", external=True)
     except nox.command.CommandFailed:
@@ -242,6 +247,8 @@ def test(session, library):
         )
 
     session.cd(library)
+    if package:
+        session.cd(f'packages/{package}')
     unit(session)
     # system tests are run 3.7 only
     if session.python == "3.7":

--- a/noxfile.py
+++ b/noxfile.py
@@ -234,7 +234,7 @@ def test(session, library):
     """
     package = ""
     if type(library) == tuple:
-            library, package = library
+        library, package = library
     try:
         session.run("git", "-C", library, "pull", external=True)
     except nox.command.CommandFailed:
@@ -248,7 +248,7 @@ def test(session, library):
 
     session.cd(library)
     if package:
-        session.cd(f'packages/{package}')
+        session.cd(f"packages/{package}")
     unit(session)
     # system tests are run 3.7 only
     if session.python == "3.7":


### PR DESCRIPTION
Updates minimum Python version required for DocFX to 3.10. See https://github.com/googleapis/synthtool/pull/1891.

Python3.10 is available by default for Ubuntu22.04, which this repository uses. No installation required.