### PR TITLE
chore: Release candidate v0.2.1rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.1](https://github.com/googleapis/python-access-context-manager/compare/v0.2.0...v0.2.1) (2024-08-14)
+## [0.2.1rc0](https://github.com/googleapis/python-access-context-manager/compare/v0.2.0...v0.2.1rc0) (2024-08-14)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.1](https://github.com/googleapis/python-access-context-manager/compare/v0.2.0...v0.2.1) (2024-08-14)
+
+
+### Bug Fixes
+
+* **deps:** Require protobuf&gt;=3.20.2, protobuf&lt;6 ([ef6827b](https://github.com/googleapis/python-access-context-manager/commit/ef6827b2aa9519abf760ddd20cd9ea0f228c4272))
+* Regenerate pb2 files for compatibility with protobuf 5.x ([ef6827b](https://github.com/googleapis/python-access-context-manager/commit/ef6827b2aa9519abf760ddd20cd9ea0f228c4272))
+
 ## [0.2.0](https://github.com/googleapis/python-access-context-manager/compare/v0.1.16...v0.2.0) (2024-02-15)
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import find_namespace_packages
 
 name = "google-cloud-access-context-manager"
 description = "Google Cloud Access Context Manager Protobufs"
-version = "0.2.0"
+version = "0.2.1"
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import find_namespace_packages
 
 name = "google-cloud-access-context-manager"
 description = "Google Cloud Access Context Manager Protobufs"
-version = "0.2.1"
+version = "0.2.1rc0"
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
## [0.2.1rc0](https://github.com/googleapis/python-access-context-manager/compare/v0.2.0...v0.2.1rc0) (2024-08-14)


### Bug Fixes

* **deps:** Require protobuf&gt;=3.20.2, protobuf&lt;6 ([ef6827b](https://github.com/googleapis/python-access-context-manager/commit/ef6827b2aa9519abf760ddd20cd9ea0f228c4272))
* Regenerate pb2 files for compatibility with protobuf 5.x ([ef6827b](https://github.com/googleapis/python-access-context-manager/commit/ef6827b2aa9519abf760ddd20cd9ea0f228c4272))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).