### PR TITLE
chore: remove pb2 file generation during post processing step

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -28,9 +28,6 @@ BLACK_VERSION = "black==22.3.0"
 LINT_PATHS = ["docs", "google", "noxfile.py", "setup.py"]
 
 
-# `grpcio-tools` 1.59.0 or newer is required for protobuf 5.x compatibility.
-GRPCIO_TOOLS_VERSION = "grpcio-tools==1.59.0"
-
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
@@ -333,28 +330,6 @@ def unit_local(session, protobuf_implementation):
         env={
             "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
         },
-    )
-
-
-@nox.session(python="3.8")
-def generate_protos(session):
-    """Generates the protos using protoc.
-
-    This session but be last to avoid overwriting the protos used in CI runs.
-
-    Some notes on the `google` directory:
-    1. The `_pb2.py` files are produced by protoc.
-    2. The .proto files are non-functional but are left in the repository
-       to make it easier to understand diffs.
-    3. The `google` directory also has `__init__.py` files to create proper modules.
-       If a new subdirectory is added, you will need to create more `__init__.py`
-       files.
-    """
-
-    session.install(GRPCIO_TOOLS_VERSION)
-    protos = [str(p) for p in (Path(".").glob("google/**/*.proto"))]
-    session.run(
-        "python", "-m", "grpc_tools.protoc", "--proto_path=.", "--python_out=.", *protos
     )
 
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -11,55 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import re
-import shutil
-import subprocess
-
-
 import synthtool as s
 import synthtool.gcp as gcp
 from synthtool.languages import python
-from synthtool.sources import git
-
-GOOGLEAPIS_REPO = "googleapis/googleapis"
-
-# Clean up googleapis
-shutil.rmtree("googleapis", ignore_errors=True)
-
-# Clone googleapis
-googleapis_url = git.make_repo_clone_url(GOOGLEAPIS_REPO)
-subprocess.run(["git", "clone", googleapis_url])
-
-# This is required in order for s.copy() to work
-s._tracked_paths.add("googleapis")
-
-common_apis = [
-    "google/api",
-    "google/iam/v1",
-    "google/longrunning",
-    "google/rpc",
-    "google/type",
-]
-
-# Create folders for dependencies of the protos that we want to compile
-_ = [os.makedirs(dir, exist_ok=True) for dir in common_apis]
-
-# Copy dependencies of the protos that we want to compile from googleapis
-_ = [s.copy(f"googleapis/{dir}/*.proto", dir) for dir in common_apis]
-
-# Copy the protos that we want to compile from googleapis
-s.copy(
-    "googleapis/google/identity/accesscontextmanager/v1/*.proto",
-    "google/identity/accesscontextmanager/v1",
-)
-s.copy(
-    "googleapis/google/identity/accesscontextmanager/type/*.proto",
-    "google/identity/accesscontextmanager/type",
-)
-
-# Clean up googleapis
-shutil.rmtree("googleapis")
 
 # ----------------------------------------------------------------------------
 #  Add templated files
@@ -79,16 +33,6 @@ s.move(
 )
 
 python.py_samples(skip_readmes=True)
-
-# Generate _pb2.py files and format them
-s.shell.run(["nox", "-s", "generate_protos"])
-
-# Clean up the folders for dependencies which are shipped via `googleapis-common-protos`
-# We should not ship them via this repository
-_ = [shutil.rmtree(dir) for dir in common_apis]
-
-# Also clean up "google/iam" directory
-shutil.rmtree("google/iam")
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
 


### PR DESCRIPTION
This PR removes pb2 file generation during the post processing step

Towards https://github.com/googleapis/google-cloud-python/issues/10887